### PR TITLE
Fix comparison within is_time() method

### DIFF
--- a/review.php
+++ b/review.php
@@ -238,7 +238,7 @@ if ( ! class_exists( 'WP_Review_Me' ) ) {
 		 */
 		public function is_time() {
 
-			$installed = (int) get_option( $this->key, false );
+			$installed = (int) get_option( $this->key, 0 );
 
 			if ( 0 === $installed ) {
 				$this->setup_date();

--- a/review.php
+++ b/review.php
@@ -240,7 +240,7 @@ if ( ! class_exists( 'WP_Review_Me' ) ) {
 
 			$installed = (int) get_option( $this->key, false );
 
-			if ( false === $installed ) {
+			if ( 0 === $installed ) {
 				$this->setup_date();
 				$installed = time();
 			}


### PR DESCRIPTION
Using false here is causing the check to ALWAYS evaluate as false since the value is being cast to an int. A check of `bool === int` can never be true, so updating this to comparing for 0 is the best solution.

This PR will fix #5 